### PR TITLE
fix all active vote proxies function...

### DIFF
--- a/migrations/026-fix-all-active-vote-proxies
+++ b/migrations/026-fix-all-active-vote-proxies
@@ -1,4 +1,4 @@
-DROP FUNCTION IF EXISTS dschief.all_active_vote_proxies_at_time(integer)
+DROP FUNCTION IF EXISTS dschief.all_active_vote_proxies_at_time(integer);
 
 CREATE OR REPLACE FUNCTION dschief.all_active_vote_proxies_at_time(arg_unix INTEGER)
 RETURNS TABLE (
@@ -10,6 +10,8 @@ WITH max_table AS (SELECT hot_and_cold, MAX(block_id) FROM (
 	SELECT hot as hot_and_cold, block_id FROM dschief.vote_proxy_created_event
 	UNION
 	SELECT cold, block_id FROM dschief.vote_proxy_created_event) u
+	JOIN vulcan2x.block b ON b.id = block_id
+	WHERE EXTRACT (EPOCH FROM b.timestamp) <= arg_unix
 	GROUP BY hot_and_cold)
 SELECT cold, hot, vote_proxy as proxy FROM dschief.vote_proxy_created_event e
 LEFT JOIN max_table as cold_max
@@ -18,6 +20,32 @@ LEFT JOIN max_table as hot_max
 ON hot = hot_max.hot_and_cold
 JOIN vulcan2x.block b ON b.id = block_id
 WHERE EXTRACT (EPOCH FROM b.timestamp) <= arg_unix
+AND block_id >= cold_max.max
+AND block_id >= hot_max.max;
+$$ LANGUAGE sql STABLE STRICT;
+
+DROP FUNCTION IF EXISTS dschief.all_active_vote_proxies(integer);
+
+CREATE OR REPLACE FUNCTION dschief.all_active_vote_proxies(arg_block_number INTEGER)
+RETURNS TABLE (
+  hot character varying(66),
+  cold character varying(66),
+  proxy character varying(66)
+) AS $$
+WITH max_table AS (SELECT hot_and_cold, MAX(block_id) FROM (
+	SELECT hot as hot_and_cold, block_id FROM dschief.vote_proxy_created_event
+	UNION
+	SELECT cold, block_id FROM dschief.vote_proxy_created_event) u
+	JOIN vulcan2x.block b ON b.id = block_id
+	WHERE b.number <= arg_block_number
+	GROUP BY hot_and_cold)
+SELECT cold, hot, vote_proxy as proxy FROM dschief.vote_proxy_created_event e
+LEFT JOIN max_table as cold_max
+ON cold = cold_max.hot_and_cold
+LEFT JOIN max_table as hot_max
+ON hot = hot_max.hot_and_cold
+JOIN vulcan2x.block b ON b.id = block_id
+WHERE b.number <= arg_block_number
 AND block_id >= cold_max.max
 AND block_id >= hot_max.max;
 $$ LANGUAGE sql STABLE STRICT;


### PR DESCRIPTION
... to include vote proxies that don't have any mkr in chief.  The only weird thing about this change is that if a user has a vote proxy and then breaks the link, the calculations will be done assuming they still have the proxy link (as long as they don't make a new proxy involving either the hot or cold address).  So I'll make a note of that behavior in the documentation.