### PR TITLE
add query to fetch all chief balance over time

### DIFF
--- a/migrations/053-all-locks-summed.sql
+++ b/migrations/053-all-locks-summed.sql
@@ -1,0 +1,24 @@
+DROP FUNCTION IF EXISTS api.all_locks_summed(CHAR,INTEGER,INTEGER);
+
+CREATE OR REPLACE FUNCTION api.all_locks_summed(unixtime_start INTEGER, unixtime_end INTEGER)
+RETURNS TABLE (
+  from_address character varying(66), 
+  immediate_caller character varying(66), 
+  lock_amount numeric(78,18),
+  block_number integer,
+  block_timestamp timestamp with time zone,
+  lock_total NUMERIC,
+  hash character varying(66)
+) AS $$
+  WITH all_locks_summed AS (
+    SELECT l.from_address, l.immediate_caller, l.lock, v.number, v.timestamp, sum(lock) OVER (PARTITION BY 0 ORDER BY number ASC) AS lock_total, t.hash
+    FROM dschief.lock l
+    INNER JOIN vulcan2x.block v ON l.block_id = v.id
+    INNER JOIN vulcan2x.transaction t ON l.tx_id = t.id
+    GROUP BY l.from_address, l.immediate_caller, l.lock, v.number, v.timestamp, t.hash
+  )
+  SELECT from_address, immediate_caller, lock, number, timestamp, lock_total, hash
+  	FROM all_locks_summed
+	  WHERE timestamp >= to_timestamp(unixtime_start)
+    AND timestamp <= to_timestamp(unixtime_end);
+$$ LANGUAGE sql STABLE STRICT;


### PR DESCRIPTION
Similar to the MKR locked by address, but fetches and sums all historical chief lock/free events for gov portal landing page chart.