### PR TITLE
update mkrLockedDelegateArray to include total locked partitioned by address

### DIFF
--- a/migrations/054-mkr-locked-delegate-array-totals.sql
+++ b/migrations/054-mkr-locked-delegate-array-totals.sql
@@ -1,0 +1,26 @@
+DROP FUNCTION IF EXISTS api.mkr_locked_delegate_array_totals(CHAR,INTEGER,INTEGER);
+
+CREATE OR REPLACE FUNCTION api.mkr_locked_delegate_array_totals(arg_address CHAR[], unixtime_start INTEGER, unixtime_end INTEGER)
+RETURNS TABLE (
+  from_address character varying(66), 
+  immediate_caller character varying(66), 
+  lock_amount numeric(78,18),
+  block_number integer,
+  block_timestamp timestamp with time zone,
+  lock_total NUMERIC,
+  hash character varying(66),
+  caller_lock_total NUMERIC
+) AS $$
+  WITH all_locks AS (
+    SELECT l.from_address, l.immediate_caller, l.lock, v.number, v.timestamp, sum(lock) OVER (PARTITION BY 0 ORDER BY number ASC) AS lock_total, t.hash, sum(lock) OVER (PARTITION BY immediate_caller ORDER BY number ASC) AS caller_lock_total
+    FROM dschief.lock l
+    INNER JOIN vulcan2x.block v ON l.block_id = v.id
+    INNER JOIN vulcan2x.transaction t ON l.tx_id = t.id
+    WHERE l.immediate_caller = ANY (arg_address)
+    GROUP BY l.from_address, l.immediate_caller, l.lock, v.number, v.timestamp, t.hash
+  )
+  SELECT from_address, immediate_caller, lock, number, timestamp, lock_total, hash, caller_lock_total
+  	FROM all_locks
+	  WHERE timestamp >= to_timestamp(unixtime_start)
+    AND timestamp <= to_timestamp(unixtime_end);
+$$ LANGUAGE sql STABLE STRICT;


### PR DESCRIPTION
Adds a column for `callerLockTotal` which accurately sums the lock/free events and partitions them by the immediate caller (whereas before it was for every caller in the selection of addresses). Keeping the original `lockTotal` in case it could be of use later.