### PR TITLE
gnosis safe manual fix

### DIFF
--- a/migrations/056-manual-lock-fix-2.sql
+++ b/migrations/056-manual-lock-fix-2.sql
@@ -1,7 +1,7 @@
-### Temporary fix since the UI uses the tx.origin of lock events to group delegation events
-### Gnosis Safe address is 0xf65475e74C1Ed6d004d5240b06E3088724dFDA5d
-### Main address used is 0xc0583df0d10c2e87ae1873b728a0bda04d8b660c
-### But also used this address twice: 0x2487fb0baa85e550fda42396d8c99ab03bd23fe1 <- this is the address being overwritten here
+--Temporary fix since the UI uses the tx.origin of lock events to group delegation events
+--Gnosis Safe address is 0xf65475e74C1Ed6d004d5240b06E3088724dFDA5d
+--Main address used is 0xc0583df0d10c2e87ae1873b728a0bda04d8b660c
+--But user also used this address twice, which we are overwriting now: 0x2487fb0baa85e550fda42396d8c99ab03bd23fe1
 
 UPDATE dschief.lock l
 SET from_address = '0xc0583df0d10c2e87ae1873b728a0bda04d8b660c'

--- a/migrations/056-manual-lock-fix-2.sql
+++ b/migrations/056-manual-lock-fix-2.sql
@@ -6,13 +6,13 @@
 UPDATE dschief.lock l
 SET from_address = '0xc0583df0d10c2e87ae1873b728a0bda04d8b660c'
 FROM vulcan2x.block b
-ON l.block_id = b.id
-WHERE b.number = 15256282
+WHERE l.block_id = b.id
+AND b.number = 15256282
 AND l.lock = -7610.756;
 
 UPDATE dschief.lock l
 SET from_address = '0xc0583df0d10c2e87ae1873b728a0bda04d8b660c'
 FROM vulcan2x.block b
-ON l.block_id = b.id
-WHERE b.number = 15256118
+WHERE l.block_id = b.id
+AND b.number = 15256118
 AND l.lock = -7.618;

--- a/migrations/056-manual-lock-fix-2.sql
+++ b/migrations/056-manual-lock-fix-2.sql
@@ -1,0 +1,18 @@
+### Temporary fix since the UI uses the tx.origin of lock events to group delegation events
+### Gnosis Safe address is 0xf65475e74C1Ed6d004d5240b06E3088724dFDA5d
+### Main address used is 0xc0583df0d10c2e87ae1873b728a0bda04d8b660c
+### But also used this address twice: 0x2487fb0baa85e550fda42396d8c99ab03bd23fe1 <- this is the address being overwritten here
+
+UPDATE dschief.lock l
+SET from_address = '0xc0583df0d10c2e87ae1873b728a0bda04d8b660c'
+FROM vulcan2x.block b
+ON l.block_id = b.id
+WHERE b.number = 15256282
+AND l.lock = -7610.756;
+
+UPDATE dschief.lock l
+SET from_address = '0xc0583df0d10c2e87ae1873b728a0bda04d8b660c'
+FROM vulcan2x.block b
+ON l.block_id = b.id
+WHERE b.number = 15256118
+AND l.lock = -7.618;

--- a/migrations/057-manual-lock-fix-3.sql
+++ b/migrations/057-manual-lock-fix-3.sql
@@ -1,0 +1,25 @@
+--Temporary fix since the UI uses the tx.origin of lock events to group delegation events
+--Gnosis Safe address is 0xf65475e74C1Ed6d004d5240b06E3088724dFDA5d
+--Main address used is 0xc0583df0d10c2e87ae1873b728a0bda04d8b660c
+--But user also used this address three more times, which we are overwriting now: 0x2487fb0baa85e550fda42396d8c99ab03bd23fe1
+
+UPDATE dschief.lock l
+SET from_address = '0xc0583df0d10c2e87ae1873b728a0bda04d8b660c'
+FROM vulcan2x.block b
+WHERE l.block_id = b.id
+AND b.number = 15263504
+AND l.lock = 8625;
+
+UPDATE dschief.lock l
+SET from_address = '0xc0583df0d10c2e87ae1873b728a0bda04d8b660c'
+FROM vulcan2x.block b
+WHERE l.block_id = b.id
+AND b.number = 15263508
+AND l.lock = 7000;
+
+UPDATE dschief.lock l
+SET from_address = '0xc0583df0d10c2e87ae1873b728a0bda04d8b660c'
+FROM vulcan2x.block b
+WHERE l.block_id = b.id
+AND b.number = 15263516
+AND l.lock = 7000;


### PR DESCRIPTION
Alter from_address of 5 lock events to handle a gnosis safe user's delegation events. Temporary measure until we have a long term solution.