### PR TITLE
Feat: live poll count query

### DIFF
--- a/migrations/065-live-poll-count.sql
+++ b/migrations/065-live-poll-count.sql
@@ -1,0 +1,11 @@
+create or replace function api.live_poll_count()
+returns table (
+  count bigint
+) as $$
+  select count(*)
+  from polling.poll_created_event
+  where end_date > extract(epoch from now()) and start_date <= extract(epoch from now()) and poll_id not in (
+	  select poll_id
+	  from polling.poll_withdrawn_event
+  )
+$$ language sql stable strict;

--- a/queries/livePollCount.graphql
+++ b/queries/livePollCount.graphql
@@ -1,0 +1,5 @@
+query livePollCount {
+  livePollCount {
+    nodes
+  }
+}


### PR DESCRIPTION
Added a PostgreSQL function and a GraphQL query to return only the number of polls active at the time.
It would count the amount of polls which have an `start_time` timestamp lower than the current timestamp and an `end_time` lower than it.

E.g.:
![image](https://user-images.githubusercontent.com/22449631/214437453-ba48a8b5-c6e9-49a3-bc3a-545645cdbd8e.png)


