### PR TITLE
Feat: Delegates pagination

### DIFF
--- a/migrations/065-live-poll-count.sql
+++ b/migrations/065-live-poll-count.sql
@@ -1,7 +1,5 @@
 create or replace function api.live_poll_count()
-returns table (
-  count bigint
-) as $$
+returns bigint as $$
   select count(*)
   from polling.poll_created_event
   where end_date > extract(epoch from now()) and start_date <= extract(epoch from now()) and poll_id not in (

--- a/migrations/065-live-poll-count.sql
+++ b/migrations/065-live-poll-count.sql
@@ -1,0 +1,11 @@
+create or replace function api.live_poll_count()
+returns table (
+  count bigint
+) as $$
+  select count(*)
+  from polling.poll_created_event
+  where end_date > extract(epoch from now()) and start_date <= extract(epoch from now()) and poll_id not in (
+	  select poll_id
+	  from polling.poll_withdrawn_event
+  )
+$$ language sql stable strict;

--- a/migrations/066-all-delegates-sorted.sql
+++ b/migrations/066-all-delegates-sorted.sql
@@ -1,0 +1,41 @@
+create type order_direction_type as enum ('ASC', 'DESC');
+
+create or replace function api.delegates(order_direction order_direction_type default 'ASC')
+returns setof dschief.vote_delegate_created_event as $$
+select *
+from dschief.vote_delegate_created_event
+order by 
+  (case when order_direction = 'ASC' then block_id end) asc,
+  (case when order_direction = 'DESC' then block_id end) desc;
+$$ language sql stable strict;
+
+create or replace function api.delegates_by_mkr(order_direction order_direction_type default 'DESC')
+returns setof dschief.vote_delegate_created_event as $$
+select A.id, A.delegate, A.vote_delegate, A.log_index, A.tx_id, A.block_id
+from dschief.vote_delegate_created_event A
+left join dschief.delegate_lock B
+on A.vote_delegate = B.contract_address
+group by A.vote_delegate, A.id, A.delegate, A.log_index, A.tx_id, A.block_id
+order by
+  (case when order_direction = 'ASC' then sum(coalesce(B.lock, 0)) end) asc,
+  (case when order_direction = 'DESC' then sum(coalesce(B.lock, 0)) end) desc;
+$$ language sql stable strict;
+
+create or replace function api.delegates_by_delegators(order_direction order_direction_type default 'DESC')
+returns setof dschief.vote_delegate_created_event as $$
+select A.id, A.delegate, A.vote_delegate, A.log_index, A.tx_id, A.block_id
+from dschief.vote_delegate_created_event A
+left join (
+  select contract_address, count(immediate_caller) as delegators
+  from (select immediate_caller, sum(lock) as delegations, contract_address
+  from dschief.delegate_lock
+  group by contract_address, immediate_caller) as D
+  where delegations > 0
+  group by contract_address
+) B
+on A.vote_delegate = B.contract_address
+group by A.vote_delegate, A.id, A.delegate, A.log_index, A.tx_id, A.block_id, B.delegators
+order by
+  (case when order_direction = 'ASC' then coalesce(delegators, 0) end) asc,
+  (case when order_direction = 'DESC' then coalesce(delegators, 0) end) desc;
+$$ language sql stable strict;

--- a/migrations/066-all-delegates-sorted.sql
+++ b/migrations/066-all-delegates-sorted.sql
@@ -1,30 +1,59 @@
 create type order_direction_type as enum ('ASC', 'DESC');
+create type order_by_type as enum ('DATE', 'MKR', 'DELEGATORS');
 
-create or replace function api.delegates(order_direction order_direction_type default 'ASC')
+-- This function will be called dynamically by api.delegates() based on the user sorting preference
+create or replace function dschief.delegates_by_date(include_expired boolean, order_direction order_direction_type default 'ASC')
 returns setof dschief.vote_delegate_created_event as $$
-select *
-from dschief.vote_delegate_created_event
+with A as (
+  select dels.*
+  from dschief.vote_delegate_created_event dels
+  left join vulcan2x.block blocks
+  on dels.block_id = blocks.id
+  where
+    -- Check that the difference between the current date and the delegate creation date is lower than a year (31536000 seconds)
+    (case when include_expired then true else extract(epoch from now()) - extract(epoch from blocks.timestamp) < 31536000 end)
+)
+select A.*
+from A
 order by 
-  (case when order_direction = 'ASC' then block_id end) asc,
-  (case when order_direction = 'DESC' then block_id end) desc;
+  case when order_direction = 'ASC' then A.block_id else -A.block_id end asc;
 $$ language sql stable strict;
 
-create or replace function api.delegates_by_mkr(order_direction order_direction_type default 'DESC')
+-- This function will be called dynamically by api.delegates() based on the user sorting preference
+create or replace function dschief.delegates_by_mkr(include_expired boolean, order_direction order_direction_type default 'DESC')
 returns setof dschief.vote_delegate_created_event as $$
-select A.id, A.delegate, A.vote_delegate, A.log_index, A.tx_id, A.block_id
-from dschief.vote_delegate_created_event A
+with A as (
+  select dels.*
+  from dschief.vote_delegate_created_event dels
+  left join vulcan2x.block blocks
+  on dels.block_id = blocks.id
+  where
+    -- Check that the difference between the current date and the delegate creation date is lower than a year (31536000 seconds)
+    (case when include_expired then true else extract(epoch from now()) - extract(epoch from blocks.timestamp) < 31536000 end)
+)
+select A.*
+from A
 left join dschief.delegate_lock B
 on A.vote_delegate = B.contract_address
 group by A.vote_delegate, A.id, A.delegate, A.log_index, A.tx_id, A.block_id
-order by
-  (case when order_direction = 'ASC' then sum(coalesce(B.lock, 0)) end) asc,
-  (case when order_direction = 'DESC' then sum(coalesce(B.lock, 0)) end) desc;
+order by 
+  case when order_direction = 'ASC' then sum(coalesce(B.lock, 0)) else -sum(coalesce(B.lock, 0)) end asc;
 $$ language sql stable strict;
 
-create or replace function api.delegates_by_delegators(order_direction order_direction_type default 'DESC')
+-- This function will be called dynamically by api.delegates() based on the user sorting preference
+create or replace function dschief.delegates_by_delegators(include_expired boolean, order_direction order_direction_type default 'DESC')
 returns setof dschief.vote_delegate_created_event as $$
-select A.id, A.delegate, A.vote_delegate, A.log_index, A.tx_id, A.block_id
-from dschief.vote_delegate_created_event A
+with A as (
+  select dels.*
+  from dschief.vote_delegate_created_event dels
+  left join vulcan2x.block blocks
+  on dels.block_id = blocks.id
+  where
+    -- Check that the difference between the current date and the delegate creation date is lower than a year (31536000 seconds)
+    (case when include_expired then true else extract(epoch from now()) - extract(epoch from blocks.timestamp) < 31536000 end)
+)
+select A.*
+from A
 left join (
   select contract_address, count(immediate_caller) as delegators
   from (select immediate_caller, sum(lock) as delegations, contract_address
@@ -35,7 +64,23 @@ left join (
 ) B
 on A.vote_delegate = B.contract_address
 group by A.vote_delegate, A.id, A.delegate, A.log_index, A.tx_id, A.block_id, B.delegators
-order by
-  (case when order_direction = 'ASC' then coalesce(delegators, 0) end) asc,
-  (case when order_direction = 'DESC' then coalesce(delegators, 0) end) desc;
+order by 
+  case when order_direction = 'ASC' then coalesce(delegators, 0) else -coalesce(delegators, 0) end asc;
 $$ language sql stable strict;
+
+-- Function exposed to the API, it dynamically calls one of the other three based on the user input
+create or replace function api.delegates(_first int, order_by order_by_type default 'DATE', order_direction order_direction_type default 'DESC', include_expired boolean default false)
+returns setof dschief.vote_delegate_created_event as $$
+begin
+  if _first > 30 or _first < 1 then
+    raise exception 'Parameter first only accepts a number between 1 and 30.';
+    return;
+  elsif order_by = 'MKR' then
+    return query select * from dschief.delegates_by_mkr(include_expired, order_direction);
+  elsif order_by = 'DELEGATORS' then
+    return query select * from dschief.delegates_by_delegators(include_expired, order_direction);
+  else
+    return query select * from dschief.delegates_by_date(include_expired, order_direction);    
+  end if;
+end;
+$$ language plpgsql stable strict;

--- a/migrations/066-all-delegates-sorted.sql
+++ b/migrations/066-all-delegates-sorted.sql
@@ -6,6 +6,7 @@ create type delegate_entry as (
   creation_date timestamp with time zone,
   expiration_date timestamp with time zone,
   expired boolean,
+  last_voted timestamp with time zone,
   delegator_count int,
   total_mkr numeric(78,18)
 );
@@ -26,27 +27,54 @@ begin
     return;
   else
     return query
-      with delegates_table as (
-        select A.delegate, A.vote_delegate, B.timestamp as creation_date, B.timestamp + '1 year' as expiration_date, now() > B.timestamp + '1 year' as expired
-        from dschief.vote_delegate_created_event A
-        left join vulcan2x.block B
-        on A.block_id = B.id
+      -- Merge poll votes from Mainnet and Arbitrum and attach the timestamp to them
+      with merged_vote_events as (
+        select voter, vote_timestamp
+        from (
+          select voter, timestamp as vote_timestamp
+          from polling.voted_event A
+          left join vulcan2x.block B
+          on A.block_id = B.id
+        ) AB
+        union all
+        select voter, vote_timestamp
+        from (
+          select voter, timestamp as vote_timestamp
+          from polling.voted_event_arbitrum C
+          left join vulcan2xarbitrum.block D
+          on C.block_id = D.id
+        ) CD
+      ),
+      delegates_table as (
+        select E.delegate, E.vote_delegate, F.timestamp as creation_date, F.timestamp + '1 year' as expiration_date, now() > F.timestamp + '1 year' as expired
+        from dschief.vote_delegate_created_event E
+        left join vulcan2x.block F
+        on E.block_id = F.id
         -- Filter out expired delegates if include_expired is false
-        where include_expired or now() < B.timestamp + '1 year'
-      ), delegations_table as (
+        where include_expired or now() < F.timestamp + '1 year'
+      ),
+      -- Merge delegates with their last votes
+      delegates_with_last_vote as (
+        select G.*, max(H.vote_timestamp) as last_voted
+        from delegates_table G
+        left join merged_vote_events H
+        on G.vote_delegate = H.voter
+        group by G.vote_delegate, G.delegate, G.creation_date, G.expiration_date, G.expired
+      ),
+      delegations_table as (
         select contract_address, count(immediate_caller) as delegators, sum(delegations) as delegations
-          from (
-            select immediate_caller, sum(lock) as delegations, contract_address
-            from dschief.delegate_lock
-            group by contract_address, immediate_caller
-          ) as D
-          where delegations > 0
-          group by contract_address
+        from (
+          select immediate_caller, sum(lock) as delegations, contract_address
+          from dschief.delegate_lock
+          group by contract_address, immediate_caller
+        ) as I
+        where delegations > 0
+        group by contract_address
       )
-      select delegates_table.*, coalesce(delegators, 0)::int as delegator_count, coalesce(delegations, 0)::numeric(78,18) as total_mkr
-      from delegates_table
+      select delegates_with_last_vote.*, coalesce(delegators, 0)::int as delegator_count, coalesce(delegations, 0)::numeric(78,18) as total_mkr
+      from delegates_with_last_vote
       left join delegations_table
-      on delegates_table.vote_delegate = delegations_table.contract_address
+      on delegates_with_last_vote.vote_delegate = delegations_table.contract_address
       order by case
         when order_by = 'DELEGATORS' then
           case when order_direction = 'ASC' then coalesce(delegators, 0)::int else -coalesce(delegators, 0)::int end
@@ -54,7 +82,7 @@ begin
           case when order_direction = 'ASC' then coalesce(delegations, 0)::numeric(78,18) else -coalesce(delegations, 0)::numeric(78,18) end
         else
           case when order_direction = 'ASC' then extract(epoch from creation_date) else -extract(epoch from creation_date) end
-        end;
+      end;
   end if;
 end;
 $$ language plpgsql stable strict;

--- a/migrations/066-all-delegates-sorted.sql
+++ b/migrations/066-all-delegates-sorted.sql
@@ -1,5 +1,5 @@
 create type order_direction_type as enum ('ASC', 'DESC');
-create type order_by_type as enum ('DATE', 'MKR', 'DELEGATORS');
+create type delegate_order_by_type as enum ('DATE', 'MKR', 'DELEGATORS');
 create type delegate_entry as (
   delegate character varying(66),
   vote_delegate character varying(66),
@@ -17,7 +17,7 @@ returns int as $$
 select 30
 $$ language sql stable strict;
 
-create or replace function api.delegates(_first int, order_by order_by_type default 'DATE', order_direction order_direction_type default 'DESC', include_expired boolean default false)
+create or replace function api.delegates(_first int, order_by delegate_order_by_type default 'DATE', order_direction order_direction_type default 'DESC', include_expired boolean default false)
 returns setof delegate_entry as $$
 declare
   max_page_size_value int := (select api.max_page_size());

--- a/migrations/066-all-delegates-sorted.sql
+++ b/migrations/066-all-delegates-sorted.sql
@@ -1,86 +1,60 @@
 create type order_direction_type as enum ('ASC', 'DESC');
 create type order_by_type as enum ('DATE', 'MKR', 'DELEGATORS');
+create type delegate_entry as (
+  delegate character varying(66),
+  vote_delegate character varying(66),
+  creation_date timestamp with time zone,
+  expiration_date timestamp with time zone,
+  expired boolean,
+  delegator_count int,
+  total_mkr numeric(78,18)
+);
 
--- This function will be called dynamically by api.delegates() based on the user sorting preference
-create or replace function dschief.delegates_by_date(include_expired boolean, order_direction order_direction_type default 'ASC')
-returns setof dschief.vote_delegate_created_event as $$
-with A as (
-  select dels.*
-  from dschief.vote_delegate_created_event dels
-  left join vulcan2x.block blocks
-  on dels.block_id = blocks.id
-  where
-    -- Check that the difference between the current date and the delegate creation date is lower than a year (31536000 seconds)
-    (case when include_expired then true else extract(epoch from now()) - extract(epoch from blocks.timestamp) < 31536000 end)
-)
-select A.*
-from A
-order by 
-  case when order_direction = 'ASC' then A.block_id else -A.block_id end asc;
+-- Small function used to return the max page size for paginated endpoints
+create or replace function api.max_page_size()
+returns int as $$
+select 30
 $$ language sql stable strict;
 
--- This function will be called dynamically by api.delegates() based on the user sorting preference
-create or replace function dschief.delegates_by_mkr(include_expired boolean, order_direction order_direction_type default 'DESC')
-returns setof dschief.vote_delegate_created_event as $$
-with A as (
-  select dels.*
-  from dschief.vote_delegate_created_event dels
-  left join vulcan2x.block blocks
-  on dels.block_id = blocks.id
-  where
-    -- Check that the difference between the current date and the delegate creation date is lower than a year (31536000 seconds)
-    (case when include_expired then true else extract(epoch from now()) - extract(epoch from blocks.timestamp) < 31536000 end)
-)
-select A.*
-from A
-left join dschief.delegate_lock B
-on A.vote_delegate = B.contract_address
-group by A.vote_delegate, A.id, A.delegate, A.log_index, A.tx_id, A.block_id
-order by 
-  case when order_direction = 'ASC' then sum(coalesce(B.lock, 0)) else -sum(coalesce(B.lock, 0)) end asc;
-$$ language sql stable strict;
-
--- This function will be called dynamically by api.delegates() based on the user sorting preference
-create or replace function dschief.delegates_by_delegators(include_expired boolean, order_direction order_direction_type default 'DESC')
-returns setof dschief.vote_delegate_created_event as $$
-with A as (
-  select dels.*
-  from dschief.vote_delegate_created_event dels
-  left join vulcan2x.block blocks
-  on dels.block_id = blocks.id
-  where
-    -- Check that the difference between the current date and the delegate creation date is lower than a year (31536000 seconds)
-    (case when include_expired then true else extract(epoch from now()) - extract(epoch from blocks.timestamp) < 31536000 end)
-)
-select A.*
-from A
-left join (
-  select contract_address, count(immediate_caller) as delegators
-  from (select immediate_caller, sum(lock) as delegations, contract_address
-  from dschief.delegate_lock
-  group by contract_address, immediate_caller) as D
-  where delegations > 0
-  group by contract_address
-) B
-on A.vote_delegate = B.contract_address
-group by A.vote_delegate, A.id, A.delegate, A.log_index, A.tx_id, A.block_id, B.delegators
-order by 
-  case when order_direction = 'ASC' then coalesce(delegators, 0) else -coalesce(delegators, 0) end asc;
-$$ language sql stable strict;
-
--- Function exposed to the API, it dynamically calls one of the other three based on the user input
 create or replace function api.delegates(_first int, order_by order_by_type default 'DATE', order_direction order_direction_type default 'DESC', include_expired boolean default false)
-returns setof dschief.vote_delegate_created_event as $$
+returns setof delegate_entry as $$
+declare
+  max_page_size_value int := (select api.max_page_size());
 begin
-  if _first > 30 or _first < 1 then
-    raise exception 'Parameter first only accepts a number between 1 and 30.';
+  if _first > max_page_size_value then
+    raise exception 'Parameter FIRST cannot be greater than %.', max_page_size_value
     return;
-  elsif order_by = 'MKR' then
-    return query select * from dschief.delegates_by_mkr(include_expired, order_direction);
-  elsif order_by = 'DELEGATORS' then
-    return query select * from dschief.delegates_by_delegators(include_expired, order_direction);
   else
-    return query select * from dschief.delegates_by_date(include_expired, order_direction);    
+    return query
+      with delegates_table as (
+        select A.delegate, A.vote_delegate, B.timestamp as creation_date, B.timestamp + '1 year' as expiration_date, now() > B.timestamp + '1 year' as expired
+        from dschief.vote_delegate_created_event A
+        left join vulcan2x.block B
+        on A.block_id = B.id
+        -- Filter out expired delegates if include_expired is false
+        where include_expired or now() < B.timestamp + '1 year'
+      ), delegations_table as (
+        select contract_address, count(immediate_caller) as delegators, sum(delegations) as delegations
+          from (
+            select immediate_caller, sum(lock) as delegations, contract_address
+            from dschief.delegate_lock
+            group by contract_address, immediate_caller
+          ) as D
+          where delegations > 0
+          group by contract_address
+      )
+      select delegates_table.*, coalesce(delegators, 0)::int as delegator_count, coalesce(delegations, 0)::numeric(78,18) as total_mkr
+      from delegates_table
+      left join delegations_table
+      on delegates_table.vote_delegate = delegations_table.contract_address
+      order by case
+        when order_by = 'DELEGATORS' then
+          case when order_direction = 'ASC' then coalesce(delegators, 0)::int else -coalesce(delegators, 0)::int end
+        when order_by = 'MKR' then
+          case when order_direction = 'ASC' then coalesce(delegations, 0)::numeric(78,18) else -coalesce(delegations, 0)::numeric(78,18) end
+        else
+          case when order_direction = 'ASC' then extract(epoch from creation_date) else -extract(epoch from creation_date) end
+        end;
   end if;
 end;
 $$ language plpgsql stable strict;

--- a/queries/delegates.graphql
+++ b/queries/delegates.graphql
@@ -1,7 +1,7 @@
 query delegates(
   $first: Int = 20
   $after: Cursor
-  $orderBy: OrderByType
+  $orderBy: DelegateOrderByType
   $orderDirection: OrderDirectionType
   $includeExpired: Boolean
 ) {

--- a/queries/delegates.graphql
+++ b/queries/delegates.graphql
@@ -21,6 +21,11 @@ query delegates(
     nodes {
       delegate
       voteDelegate
+      creationDate
+      expirationDate
+      expired
+      delegatorCount
+      totalMkr
     }
   }
 }

--- a/queries/delegates.graphql
+++ b/queries/delegates.graphql
@@ -1,11 +1,17 @@
-query delegatesByDelegators(
+query delegates(
+  $first: Int = 20
   $after: Cursor
+  $orderBy: OrderByType
   $orderDirection: OrderDirectionType
+  $includeExpired: Boolean
 ) {
-  delegatesByDelegators(
-    first: 30
+  delegates(
+    first: $first
+    _first: $first
     after: $after
+    orderBy: $orderBy
     orderDirection: $orderDirection
+    includeExpired: $includeExpired
   ) {
     totalCount
     pageInfo {

--- a/queries/delegates.graphql
+++ b/queries/delegates.graphql
@@ -24,6 +24,7 @@ query delegates(
       creationDate
       expirationDate
       expired
+      lastVoted
       delegatorCount
       totalMkr
     }

--- a/queries/delegatesByDelegators.graphql
+++ b/queries/delegatesByDelegators.graphql
@@ -1,0 +1,20 @@
+query delegatesByDelegators(
+  $after: Cursor
+  $orderDirection: OrderDirectionType
+) {
+  delegatesByDelegators(
+    first: 30
+    after: $after
+    orderDirection: $orderDirection
+  ) {
+    totalCount
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      delegate
+      voteDelegate
+    }
+  }
+}

--- a/queries/livePollCount.graphql
+++ b/queries/livePollCount.graphql
@@ -1,0 +1,5 @@
+query livePollCount {
+  livePollCount {
+    nodes
+  }
+}

--- a/queries/livePollCount.graphql
+++ b/queries/livePollCount.graphql
@@ -1,5 +1,3 @@
 query livePollCount {
-  livePollCount {
-    nodes
-  }
+  livePollCount
 }


### PR DESCRIPTION
Add pagination and sorting to the delegates endpoint.

This new GraphQL query supports pagination, it returns a maximum of 30 delegates per request and allow sorting by date, mkr or delegators, ascending or descending and optionally excluding expired delegates.
The query returns the following fields:
`delegate, voteDelegate, creationDate, expirationDate, expired, lastVoted, delegatorCount, totalMkr`

In the screenshot below you can see a query sorted by MKR descending:
![image](https://user-images.githubusercontent.com/22449631/215834310-31e8a025-88b4-49ab-a08c-5876b207e024.png)

Note: lastVoted is showing as null for all delegates in my local environment because I don't have poll votes data synced, but I tested it as a SQL query in the staging environment through Postico and the values matched with the ones in the portal.
Note 2: This PR contains a small change on the `livePollCount` query so it returns a single value instead of a table of 1 row.
