### PR TITLE
Fix incompatible broken migration

### DIFF
--- a/migrations/067-updated-live-poll-count.sql
+++ b/migrations/067-updated-live-poll-count.sql
@@ -1,3 +1,4 @@
+drop function if exists api.live_poll_count; -- must drop because return type changed
 create or replace function api.live_poll_count()
 returns bigint as $$
   select count(*)

--- a/migrations/067-updated-live-poll-count.sql
+++ b/migrations/067-updated-live-poll-count.sql
@@ -1,7 +1,5 @@
 create or replace function api.live_poll_count()
-returns table (
-  count bigint
-) as $$
+returns bigint as $$
   select count(*)
   from polling.poll_created_event
   where end_date > extract(epoch from now()) and start_date <= extract(epoch from now()) and poll_id not in (


### PR DESCRIPTION
Due to a change made to migration 65 after it was merged, the following migrations can't be run in staging, so rolled back 65 to its previous state and changed the function in a new migration 67.