### PR TITLE
Add filter argument to query

### DIFF
--- a/queries/delegates.graphql
+++ b/queries/delegates.graphql
@@ -4,6 +4,7 @@ query delegates(
   $orderBy: DelegateOrderByType
   $orderDirection: OrderDirectionType
   $includeExpired: Boolean
+  $filter: DelegateEntryFilter
 ) {
   delegates(
     first: $first
@@ -12,6 +13,7 @@ query delegates(
     orderBy: $orderBy
     orderDirection: $orderDirection
     includeExpired: $includeExpired
+    filter: $filter
   ) {
     totalCount
     pageInfo {


### PR DESCRIPTION
Added a `filter` parameter to the delegates query to be able to filter by recognized/shadow delegates.