### PR TITLE
Feat/delegates pagination

### DIFF
--- a/migrations/068-delegation-metrics.sql
+++ b/migrations/068-delegation-metrics.sql
@@ -1,0 +1,13 @@
+create type delegation_metrics_entry as (
+  delegator_count bigint,
+  total_mkr_delegated numeric
+);
+
+create or replace function api.delegation_metrics()
+returns delegation_metrics_entry as $$
+  select count(*) as delegator_count, sum(delegations) as total_mkr_delegated
+  from (select immediate_caller, sum(lock) as delegations
+  from dschief.delegate_lock
+  group by immediate_caller) A
+  where delegations > 0
+$$ language sql stable strict;

--- a/queries/delegateContractsByOwners.graphql
+++ b/queries/delegateContractsByOwners.graphql
@@ -1,8 +1,0 @@
-query delegateContractsByOwners($owners: [String!]) {
-  allDelegates(filter: { delegate: { in: $owners } }) {
-    nodes {
-      delegate
-      voteDelegate
-    }
-  }
-}

--- a/queries/delegationMetrics.graphql
+++ b/queries/delegationMetrics.graphql
@@ -1,0 +1,6 @@
+query delegationMetrics {
+  delegationMetrics {
+    delegatorCount
+    totalMkrDelegated
+  }
+}


### PR DESCRIPTION
## What does this PR do:
- It removes the `delegateContractsByOwners` query that was included on the last PR as it was not necessary for the voting portal endpoint migrations anymore.
- It adds a new migration and GraphQL query to get delegation stats like the total amount of delegators and the total amount of MKR delegated, necessary as those are not possible to be calculated on the Voting Portal anymore.