### PR TITLE
update action version

### DIFF
--- a/.github/workflows/aws-prod.yml
+++ b/.github/workflows/aws-prod.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-access-key-id: ${{ secrets.POLLINGDB2_PROD_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.POLLINGDB2_PROD_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/aws-staging.yml
+++ b/.github/workflows/aws-staging.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-access-key-id: ${{ secrets.POLLINGDB2_STAGING_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.POLLINGDB2_STAGING_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
We'll need to update the GitHub actions that rely on node12 since it's deprecated now. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/