### PR TITLE
MKR delegated to group

### DIFF
--- a/migrations/070-total-mkr-delegated-to-group.sql
+++ b/migrations/070-total-mkr-delegated-to-group.sql
@@ -1,0 +1,6 @@
+create or replace function api.total_mkr_delegated_to_group(delegates char[])
+returns numeric as $$
+  select sum(lock)
+  from dschief.delegate_lock
+  where contract_address = ANY (delegates)
+$$ language sql stable strict;

--- a/queries/totalMkrDelegatedToGroup.graphql
+++ b/queries/totalMkrDelegatedToGroup.graphql
@@ -1,0 +1,3 @@
+query totalMkrDelegatedToGroup($delegates: [String]!) {
+  totalMkrDelegatedToGroup(delegates: $delegates)
+}


### PR DESCRIPTION
Added a query to return the total amount of MKR delegated to a group of delegate addresses passed as a parameter, this can be used for CVC stats

![image](https://user-images.githubusercontent.com/22449631/229900374-e1962231-7a5f-44a4-89e2-0abe8933df18.png)
