### PR TITLE
Script to update constraint

### DIFF
--- a/migrations/074-unique-lock-update.sql
+++ b/migrations/074-unique-lock-update.sql
@@ -1,0 +1,5 @@
+-- existing contraint is (log_index, tx_id) and this does not work with multi-send transactions from gnosis safe
+ALTER TABLE dschief.delegate_lock DROP CONSTRAINT delegate_lock_log_index_tx_id_key;
+
+-- add a new constraint that includes the lock value and the from_address (delegate contract)
+ALTER TABLE dschief.delegate_lock ADD CONSTRAINT delegate_lock_key UNIQUE (log_index, tx_id, from_address, lock);


### PR DESCRIPTION
There is an issue parsing mutli-send txs that perform multiple locks events due the unique constraint of `(log_index, tx_id)`

This alters the constraint to also include the `lock` amt and `from_address` (which is the delegate)